### PR TITLE
Initialize Quarto blog with GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,25 @@
+name: Deploy Quarto site
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: quarto-dev/quarto-actions/setup@v2
+      - uses: actions/configure-pages@v3
+      - run: quarto render
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: _site
+      - uses: actions/deploy-pages@v1
+        with:
+          branch: gh-pages
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+_site/
+*.ipynb
+*.nb.html
+.Rhistory
+.Rdata
+.Rproj.user/
+.DS_Store

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+maximerivest.com

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # maximerivest-blog
-The repo behind my personal website/blog.
+
+This repository contains the source for [maximerivest.com](https://maximerivest.com).
+Content is written with [Quarto](https://quarto.org) using notebooks or
+Python scripts in Jupytext "percent" format.
+
+## Writing posts
+
+Add new `.qmd` or `.ipynb` files under `posts/`. Python scripts can be
+written with `# %%` cells and converted using Jupytext.
+Run `quarto preview` to build and preview the site locally.
+
+## Deployment
+
+Changes pushed to `main` are built and deployed automatically to the
+`gh-pages` branch via GitHub Actions. The `CNAME` file configures the
+custom domain `maximerivest.com` for GitHub Pages.

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,0 +1,21 @@
+project:
+  type: website
+  output-dir: _site
+
+website:
+  title: "Maxime Rivest"
+  description: "Personal blog"
+  site-url: "https://maximerivest.com"
+  navbar:
+    right:
+      - href: https://twitter.com/maximerivest
+        text: Twitter
+  page-navigation: true
+  repo-url: https://github.com/maximerivest/blog
+  repo-actions: [edit]
+
+format:
+  html:
+    theme: flatly
+    css: styles.css
+    toc: true

--- a/posts/welcome.qmd
+++ b/posts/welcome.qmd
@@ -1,0 +1,11 @@
+---
+title: "Welcome"
+date: 2023-09-14
+---
+
+This is a sample post created with Quarto. You can edit or remove it.
+
+```{r}
+#| echo: false
+plot(1:10, 1:10)
+```

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,3 @@
+body {
+  font-family: system-ui, sans-serif;
+}


### PR DESCRIPTION
## Summary
- add Quarto configuration and a sample post
- configure GitHub Actions workflow for automatic deployment to `gh-pages`
- add CNAME and ignore build artifacts
- document how to write posts and deploy

## Testing
- `quarto check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686988a2ddf88325b1e49ef850356568